### PR TITLE
Experimenting with prefixing string literals

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interpolate"
-version = "0.2.3"
+version = "0.3.0"
 license = "MIT"
 authors = ["Anthony Nowell <anowell@gmail.com>"]
 
@@ -8,6 +8,7 @@ description = "A simple form of string interpolation"
 documentation = "http://docs.rs/interpolate"
 repository = "https://github.com/anowell/interpolate"
 readme = "README.md"
+edition = "2021"
 
 [lib]
 crate-type = ["proc-macro"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 Interpolate
 ==========
 
-A simple form of Rust string interpolation, e.g., `s!("Today is {date}")`.
+A simple form of Rust string interpolation, 
+
+Simple interpolation with format string literal, e.g., `f"Today is {date}"`.
 
 [Documentation](http://docs.rs/interpolate)
 
@@ -10,39 +12,41 @@ A simple form of Rust string interpolation, e.g., `s!("Today is {date}")`.
 
 ## Usage
 
-Note: `interpolate` currently requires some experimental functionality in nightly.
 
 ```rust
-#![feature(proc_macro_hygiene)]
-use interpolate::s;
+use interpolate::fstring;
 
-let name = "Jane";
-let fav_num = 32;
-let greeting = s!("{name}'s favorite number is {fav_num}");
+#[fstring]
+fn foo() {
+    let name = "Hercules";
+    let greet = f"Hello, {name}";
+}
 ```
 
-Escaping braces is accomplished similar to escaping other format strings in rust.
+- Starting with Edition 2021, the prefix literal is reserved syntax, so you have to add a space `f "Hello {name}"`.
+- The implementation simply changes `f"literal"` into `format!("literal")`.
+- The `[fstring]` annotation is needed on an [item](https://doc.rust-lang.org/reference/items.html) because this is implemented as an [attribute macro](https://doc.rust-lang.org/reference/procedural-macros.html#attribute-macros).
 
-> The literal characters { and } may be included in a string by preceding them with the same character. For example, the { character is escaped with {{ and the } character is escaped with }}.
 
 ## Idea
 
-The goal of interpolate is to provide basic string interpolation functionality with a very light-weight syntax.
-
-It is not:
-
-- A full replacement for `format!`, `println!`, and related macros
-- Capable of non-trivial formatting of types
-- Anything that requires extensive documentation
+The goal of interpolate was to explore basic string interpolation functionality with a very light-weight syntax.
 
 I created this after a working on a CLI tools where I used `format!` a LOT.
 I really wanted something lighter weight like Scala's `s"Today is $date"`, so
-I decided to experiment here, with the idea of possibly adding to the
-discussions around strings (like
-[allowing literals to be used as String](https://internals.rust-lang.org/t/pre-rfc-allowing-string-literals-to-be-either-static-str-or-string-similar-to-numeric-literals/5029)
-and [custom string literals](https://internals.rust-lang.org/t/pre-rfc-custom-string-literals/5037).
-I frequently find myself wondering if any of these ideas could have a more central role in rust:
+I decided to experiment here.
 
-- `println!("Hello {name}")` to basically mean `println!("Hello {name}", name=name)`
-- `let full_name = s"{first_name} {last_name}"` instead of `format!("{} {}", first_name, last_name)`
-- `let msg = s"Hello"` instead of `"Hello".to_string()`
+Originally it used `s!("Hi, {name}")`. To my delight, [Rust 1.58](https://blog.rust-lang.org/2022/01/13/Rust-1.58.0.html) started capturing identifiers in format strings, which basically meant this crate could be implemented in 2 lines:
+
+```
+pub use std::format as s;
+pub use std::println as p;
+```
+
+So I started experimenting with prefix literal syntax.
+
+
+Reference Material:
+- [allowing literals to be used as String](https://internals.rust-lang.org/t/pre-rfc-allowing-string-literals-to-be-either-static-str-or-string-similar-to-numeric-literals/5029)
+- [custom string literals](https://internals.rust-lang.org/t/pre-rfc-custom-string-literals/5037).
+- [RFC 3101 - Reserved Literal Prefixes](https://github.com/rust-lang/rfcs/blob/master/text/3101-reserved_prefixes.md)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,192 +1,85 @@
 #![crate_type = "proc-macro"]
-//! A simple form of Rust string interpolation
+//! Simple interpolation with format string literal
 //!
-//! `interpolate` provides basic string interpolation
-//! functionality with a very light-weight syntax.
+//! `interpolate` provides basic format string literal syntax
+//! that explores the design space reserved by [RFC 3101](https://github.com/rust-lang/rfcs/blob/master/text/3101-reserved_prefixes.md)
 //!
 //! ```no_run
-//! #![feature(use_extern_macros, prox_macro_non_items)]
-//! use interpolate::s;
+//! use interpolate::fstring;
 //!
-//! let name = "Hercules";
-//! let greet = s!("Hello, {name}");
-//! let sos = s!("HELP, {name.to_uppercase()}");
+//! #[fstring]
+//! fn foo() {
+//!     let name = "Hercules";
+//!     let greet = f"Hello, {name}";
+//! }
 //! ```
+//!
+//! - Starting with Edition 2021, the prefix literal is reserved syntax, so you have to add a space `f "Hello {name}"`.
+//! - The implementation simply changes `f"literal"` into `format!("literal")`.
+//! - The `[fstring]` annotation is needed on an [item](https://doc.rust-lang.org/reference/items.html) because this is implemented as an [attribute macro](https://doc.rust-lang.org/reference/procedural-macros.html#attribute-macros).
 //!
 //! That is all.
 
-#![feature(proc_macro_hygiene, proc_macro_quote)]
-
 extern crate proc_macro;
+use std::iter::FromIterator;
 
-use proc_macro::{quote, TokenStream, TokenTree};
-use std::str::FromStr;
+use proc_macro::{Delimiter, Group, Ident, Punct, Spacing, TokenStream, TokenTree};
 
-// Simple state machine for the current part of string being processed
-#[derive(Debug, Copy, Clone)]
-enum Position {
-    // Any literal text that precedes a '$' interpolation
-    Literal,
-    // The delimeter(s) starting the interpolation, e.g., `{`
-    ExpressionDelim,
-    // An interpolation expression wrapped in braces, e.g., `{foo}`
-    ExpressionWrapped,
-    // Everything following the interpolation expression
-    // (which may or may not contain additional expressions to interpolate)
-    Rest,
-}
+fn process_stream(item: TokenStream) -> TokenStream {
+    let mut output = Vec::new();
+    let mut format_ident: Option<Ident> = None;
 
-#[derive(Default)]
-struct FmtArgs {
-    fmt: String,
-    args: Vec<proc_macro::TokenStream>,
-}
-impl FmtArgs {
-    fn new() -> FmtArgs {
-        FmtArgs::default()
-    }
-}
-
-// Splits the text into 3 parts:
-// literal, interpolated expression, and remainder of string slice
-// any one of these pieces may be empty:
-//   if literal is empty, the text starts with an expression
-//   if expression is empty, there are no expressions
-//   if remainder is empty, then we've reached the end of the string
-#[allow(unstable_name_collisions)]
-fn split_interpolate(text: &str) -> FmtArgs {
-    let mut state = Position::Literal;
-
-    // Walk the string finding indexes for:
-    //   delim: the first '$' delimeter
-    //   exp_start: start of the interpolation expression (without delimeters)
-    //   exp_end: the index immediately after the last char of the expression
-    //   rest: the index of the first character of the rest of the string
-    let mut fmt_args = FmtArgs::new();
-    let (mut lit_start, mut delim, mut exp_start, mut exp_end) =
-        (0, text.len(), text.len(), text.len());
-
-    for (i, c) in text.char_indices() {
-        match state {
-            Position::Literal if c == '{' => {
-                state = Position::ExpressionDelim;
-                delim = i;
-            }
-            Position::ExpressionDelim if c == '{' => {
-                state = Position::Literal;
-                delim = text.len();
-            }
-            Position::ExpressionDelim => {
-                state = Position::ExpressionWrapped;
-                exp_start = i;
-            }
-            Position::ExpressionWrapped if c == '}' => {
-                state = Position::Rest;
-                exp_end = i;
-            }
-            Position::Rest if c == '}' => {
-                state = Position::ExpressionWrapped;
-                exp_end = text.len();
-            }
-            Position::Rest => {
-                let (lit, arg) = unsafe {
-                    (
-                        text.get_unchecked(lit_start..delim),
-                        text.get_unchecked(exp_start..exp_end)
-                            .trim()
-                            .replace("{{", "{")
-                            .replace("}}", "}"),
-                    )
-                };
-                fmt_args.fmt.push_str(lit);
-                fmt_args.fmt.push_str("{}");
-                fmt_args.args.push(
-                    proc_macro::TokenStream::from_str(&arg)
-                        .expect("interpolation expression is not a valid token stream"),
-                );
-                lit_start = i;
-                if c == '{' {
-                    state = Position::ExpressionDelim;
-                    delim = i;
-                } else {
-                    state = Position::Literal;
-                    delim = text.len();
+    for tree in item {
+        if let Some(f_ident) = format_ident {
+            match tree.clone() {
+                // Here's where we replace f"lit" with format!("lit")
+                tree @ TokenTree::Literal(_) => {
+                    // println!("Constructing format!({tree})");
+                    output.push(TokenTree::from(Ident::new("format", f_ident.span())));
+                    output.push(TokenTree::from(Punct::new('!', Spacing::Alone)));
+                    let group = Group::new(Delimiter::Parenthesis, TokenStream::from(tree));
+                    output.push(TokenTree::from(group));
+                    format_ident = None;
+                    continue;
+                }
+                _ => {
+                    // println!("Found the format identifier without a literal.");
+                    output.push(TokenTree::from(f_ident));
                 }
             }
-            _ => (),
+        }
+        format_ident = None;
+
+        match tree {
+            TokenTree::Group(group) => {
+                let new_stream = process_stream(group.stream());
+                let new_group = Group::new(group.delimiter(), new_stream);
+                output.push(TokenTree::from(new_group));
+            }
+            TokenTree::Ident(ident) => {
+                // println!("Ident: {ident}");
+                if ident.to_string() == "f" {
+                    format_ident = Some(ident);
+                } else {
+                    output.push(TokenTree::from(ident));
+                }
+            }
+            tree @ TokenTree::Punct(_) => output.push(tree),
+            tree @ TokenTree::Literal(_) => output.push(tree),
         }
     }
 
-    match state {
-        Position::ExpressionWrapped | Position::ExpressionDelim => {
-            panic!("Interpolated expression is not closed")
-        }
-        Position::Rest => {
-            let (lit, arg) = unsafe {
-                (
-                    text.get_unchecked(lit_start..delim),
-                    text.get_unchecked(exp_start..exp_end)
-                        .trim()
-                        .replace("{{", "{")
-                        .replace("}}", "}"),
-                )
-            };
-            fmt_args.fmt.push_str(lit);
-            fmt_args.fmt.push_str("{}");
-            fmt_args.args.push(
-                proc_macro::TokenStream::from_str(&arg)
-                    .expect("interpolation expression is not a valid token stream"),
-            );
-        }
-        Position::Literal => {
-            let lit = unsafe { text.get_unchecked(lit_start..) };
-            fmt_args.fmt.push_str(lit);
-        }
+    if let Some(f_ident) = format_ident {
+        // println!("Found the format identifier without a literal at end of TokenStream.");
+        output.push(TokenTree::from(f_ident));
     }
-    // println!("FMT: {:?}", fmt_args.fmt);
-    // for arg in &fmt_args.args {
-    //   println!("  ARG: {:?}", arg);
-    // }
-    fmt_args
+
+    TokenStream::from_iter(output)
 }
 
-fn parse_args(input: TokenStream) -> FmtArgs {
-    let mut trees = input.into_iter();
-    let tree = trees
-        .next()
-        .expect("macro only accepts a single string literal");
-    if let Some(_) = trees.next() {
-        panic!("macro only accepts a single string literal");
-    }
-    // TODO: panic if multiple tokens
-    let text = match tree {
-        TokenTree::Literal(lit) => lit.to_string(),
-        _ => panic!("macro only accepts a single string literal"),
-    };
-
-    let first_quote = text
-        .find('"')
-        .expect("macro only accepts a single string literal");
-    if first_quote != 0 {
-        panic!("macro does not accept raw string literals");
-    }
-    let text = unsafe { text.get_unchecked(1..(text.len() - 1)) };
-
-    split_interpolate(&text)
-}
-
-/// Inline interpolation macro
-#[proc_macro]
-#[allow(unused_variables)]
-pub fn s(input: TokenStream) -> TokenStream {
-    let FmtArgs { fmt, args } = parse_args(input);
-    quote!({ format!(#fmt, #(#args),*) })
-}
-
-/// Inline interpolating printing macro
-#[proc_macro]
-#[allow(unused_variables)]
-pub fn p(input: TokenStream) -> TokenStream {
-    let FmtArgs { fmt, args } = parse_args(input);
-    quote!({ println!(#fmt, #(#args),*) })
+#[proc_macro_attribute]
+pub fn fstring(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let output = process_stream(item);
+    // println!("{output}");
+    output
 }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tests"
 version = "0.1.0"
 authors = ["Anthony Nowell <anowell@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 interpolate = { path = ".." }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,99 +1,33 @@
-#![feature(proc_macro_hygiene)]
-#![feature(non_ascii_idents)]
-
 extern crate interpolate;
 
 #[cfg(test)]
 mod tests {
-    use interpolate::s;
+    use interpolate::fstring;
+
+    fn f() -> &'static str {
+        "hi"
+    }
 
     #[test]
-    fn wrapped() {
+    #[fstring]
+    fn no_args() {
+        assert_eq!("Hello", f"Hello");
+    }
+
+    #[test]
+    #[fstring]
+    fn interpolation() {
         let name  = "Elsa";
-        assert_eq!("Hello, Elsa.", s!("Hello, {name}."));
-        assert_eq!("Hello, Elsa.", s!("Hello, { name }."));
+        assert_eq!("Hello, Elsa.", f"Hello, {name}.");
     }
 
     #[test]
-    fn prefix() {
-        let name  = "Mulan";
-        assert_eq!("Mulan, the brave.", s!("{name}, the brave."));
-        assert_eq!("Mulan, the brave.", s!("{ name }, the brave."));
+    #[fstring]
+    fn ident_collision() {
+        let msg  = f();
+        let f = "hello";
+        assert_eq!("hi", msg);
+        assert_eq!("hello", f);
     }
 
-    #[test]
-    fn suffix() {
-        let name  = "Jafar";
-        assert_eq!("Vile Jafar", s!("Vile {name}"));
-        assert_eq!("Vile Jafar", s!("Vile { name }"));
-    }
-
-    #[test]
-    fn pre_and_suffix() {
-        let name  = "Lilo";
-        let name2 = "Stitch";
-        assert_eq!("Lilo and Stitch", s!("{name} and {name2}"));
-    }
-
-    #[test]
-    fn single_expression_only() {
-        let name  = "Prince Charming";
-        assert_eq!("Prince Charming", s!("{name}"));
-    }
-
-    #[test]
-    fn escapes() {
-        assert_eq!("{ input", s!("{{ input"));
-        assert_eq!("} input", s!("}} input"));
-        let val = "foo";
-        assert_eq!("{ foo }", s!("{{ {val} }}"));
-        // Please don't actually do this...
-        assert_eq!("f", s!("{val.chars().filter(|c| {{ *c=='f' }}).collect::<String>()}"));
-    }
-
-
-    #[test]
-    fn connected_expressions() {
-        let first_name  = "Mickey";
-        let last_name = "Mouse";
-        assert_eq!("MickeyMouse", s!("{first_name}{last_name}"));
-        assert_eq!("MickeyMouse", s!("{ first_name }{ last_name }"));
-    }
-
-    #[test]
-    fn no_expression() {
-        assert_eq!("Doc", s!("Doc"));
-    }
-
-    #[test]
-    fn reuse() {
-        let name = "Aladdin";
-        assert_eq!(
-            "Aladdin is the star of Aladdin.",
-            s!("{name} is the star of {name}.")
-        );
-    }
-
-    #[test]
-    fn xid_start_continue() {
-        let _full_name_  = "Judy Hopps";
-        assert_eq!("Judy Hopps!", s!("{_full_name_}!"));
-
-        #[allow(non_snake_case)]
-        let Ö𞹼𝒜𝟋ↈ  = "Olaf";
-        assert_eq!("~Olaf~", s!("~{Ö𞹼𝒜𝟋ↈ}~"));
-    }
-
-    #[test]
-    fn expressions() {
-        let ducks = vec!["Huey", "Dewey", "Louie"];
-        assert_eq!("Dewey", s!("{ducks[1]}"));
-        assert_eq!("HueyDeweyLouie", s!("{ducks.concat()}"));
-
-        // Please, don't actually do this
-        assert_eq!(
-            "hueydeweylouie",
-            s!("{ducks.iter().map(|s|s.to_lowercase()).collect::<Vec<_>>().concat()}")
-        );
-    }
 }


### PR DESCRIPTION
Experimental.

```rust
use interpolate::fstring;

#[fstring]
fn foo() {
    let name = "Hercules";
    let greet = f"Hello, {name}";
}
```


[Rendered README](https://github.com/anowell/interpolate/blob/fstring/README.md)